### PR TITLE
fixed android; using alignItems: center instead of right

### DIFF
--- a/screens/setting.js
+++ b/screens/setting.js
@@ -31,7 +31,7 @@ export default function SettingScreen({ navigation }) {
         <View style={{ flex: 1, backgroundColor: '#8C2032', padding: 20 }}>
             <View style={globalStyles.settingOption}>
                 <Text>Setting option 1</Text>
-                <View style={{alignItems: 'right'}}>
+                <View style={{alignItems: 'center'}}>
                     <Switch        
                         trackColor={{ false: 'gray', true: 'green' }}
                         onValueChange={switchOne}
@@ -41,7 +41,7 @@ export default function SettingScreen({ navigation }) {
             </View>
             <View style={globalStyles.settingOption}>
                 <Text>Setting option 2</Text>
-                <View style={{alignItems: 'right'}}>
+                <View style={{alignItems: 'center'}}>
                     <Switch                      
                         trackColor={{ false: 'gray', true: 'green' }}
                         onValueChange={switchTwo}
@@ -51,7 +51,7 @@ export default function SettingScreen({ navigation }) {
             </View>
             <View style={globalStyles.settingOption}>
                 <Text>Setting option 3</Text>
-                <View style={{alignItems: 'right'}}>
+                <View style={{alignItems: 'center'}}>
                     <Switch                      
                         trackColor={{ false: 'gray', true: 'green' }}
                         onValueChange={switchThree}


### PR DESCRIPTION
for posterity, let's figure out why alignItems: 'center' doesn't seem to work on android. i'm sure other people have had this issue as well, so there's bound to be stackoverflow threads on this sort of thing